### PR TITLE
feat(#20): add `openapi` validation against multiple schemas

### DIFF
--- a/src/ndto_generator.erl
+++ b/src/ndto_generator.erl
@@ -92,6 +92,8 @@ generate(Name, Schema, Format) ->
 chain_conditions(FunCalls, 'andalso' = Operator) ->
     chain_conditions(FunCalls, Operator, erl_syntax:atom(true));
 chain_conditions(FunCalls, 'orelse' = Operator) ->
+    chain_conditions(FunCalls, Operator, erl_syntax:atom(false));
+chain_conditions(FunCalls, 'xor' = Operator) ->
     chain_conditions(FunCalls, Operator, erl_syntax:atom(false)).
 
 false_clause() ->


### PR DESCRIPTION
Includes validation against the `not` keyword.

closes #20, closes #21